### PR TITLE
Query attributes

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -62,6 +62,15 @@ app.get("/events", (req, res, next) => {
   }
 });
 
+app.get("/attributes", async (_req, res, next) => {
+  try {
+    const result = await redshift.getAllAttributes();
+    res.status(200).send(JSON.stringify(result));
+  } catch (error) {
+    next(error);
+  }
+});
+
 // Error handler
 app.use((err, _req, res, _next) => {
   console.error(err); // Writes more extensive information to the console log

--- a/src/lib/redshift-pg.js
+++ b/src/lib/redshift-pg.js
@@ -5,6 +5,7 @@ const events = require("../sql/events");
 const users = require("../sql/users");
 const { VALID_TIME_UNIT } = require("../lib/globals");
 const formatDataBy = require("../utils/format-records");
+const formatAttributes = require('../utils/format-attributes')
 
 const AGGREGATE_EVENTS = {
   total: events.getTotalEventsBy,
@@ -93,8 +94,23 @@ async function getAllEventNames() {
   return result.rows;
 }
 
+async function getAllAttributes() {
+  let result;
+
+  try {
+    let eventAttributes = dbQuery(events.getAllEventAttributes());
+    let userAttributes = dbQuery(users.getAllUserAttributes());
+    result = await Promise.all([eventAttributes, userAttributes]);
+    let formattedResult = formatAttributes(result);
+    return formattedResult
+  } catch (error) {
+    console.error(error);
+  }
+}
+
 module.exports = {
   getAllEventNames,
   getAggregatedEventsBy,
   getAggregatedUsersBy,
+  getAllAttributes,
 };

--- a/src/sql/events.js
+++ b/src/sql/events.js
@@ -9,6 +9,16 @@ function getAllEventNames() {
   `;
 }
 
+function getAllEventAttributes() {
+  return `
+  SELECT 
+    DISTINCT
+      JSON_SERIALIZE(event_attributes)
+    FROM
+      events
+  `
+}
+
 function getTotalEventsBy(timeUnit) {
   if (!VALID_TIME_UNIT[timeUnit]) return "Invalid time unit provided";
 
@@ -159,4 +169,5 @@ module.exports = {
   getMaxPerUserBy,
   getMinPerUserBy,
   getMedianPerUserBy,
+  getAllEventAttributes,
 };

--- a/src/sql/users.js
+++ b/src/sql/users.js
@@ -1,5 +1,15 @@
 const { VALID_TIME_UNIT } = require("../lib/globals.js");
 
+function getAllUserAttributes() {
+  return `
+  SELECT 
+    DISTINCT
+      JSON_SERIALIZE(user_attributes)
+    FROM
+      users
+  `
+}
+
 function getTotalUsersBy(timeUnit) {
   if (!VALID_TIME_UNIT[timeUnit]) return "Invalid time unit provided";
 
@@ -20,4 +30,5 @@ function getTotalUsersBy(timeUnit) {
 
 module.exports = {
   getTotalUsersBy,
+  getAllUserAttributes,
 };

--- a/src/utils/format-attributes.js
+++ b/src/utils/format-attributes.js
@@ -1,0 +1,27 @@
+function formatAttributes(result) {
+  let attributeObj = {
+    event: getDistinctAttributes(result[0]),
+    user: getDistinctAttributes(result[1])
+  }
+
+  return attributeObj;
+}
+
+function getDistinctAttributes(attributeArr) {
+  let formattedAttributes = {};
+  attributeArr.rows.forEach(row => {
+    let attributes = JSON.parse(row.json_serialize);
+    for (let attribute in attributes) {
+      let value = attributes[attribute];
+      if (!newObj.hasOwnProperty(attribute)) {
+        newObj[attribute] = [];
+      }
+      if (!newObj[attribute].includes(value)) {
+        newObj[attribute].push(String(value))
+      }
+    }
+  })
+  return formattedAttributes;
+}
+
+module.exports = formatAttributes


### PR DESCRIPTION
This pull request is for the work done to add functionality to backend to query, format, and return user/event attributes to our front end application. This pull request includes a route addition for "/attributes", queries for both user and event attributes, a utility function to format the data after being queried from redshift,  and a getAllAttributes function that orchestrates all steps needed to return the appropriate data back to the application. Below is a sample snapshot of the formatted attribute data that will be sent back to the front end:

```
{
"event": {
   "device":["desktop","tablet","mobile"],
   "location":["San Francisco","Chicago","Seattle","Boston"],
   "product":["iPhone","AirPods","iPad"],
   "amount":["999.99","149.99"]
   },
"user": {
   "attribute1":["value1","value3","value5"],
   "attribute2":["value2","value4","value6"]
   }
}
```
