### PR TITLE
Python UDF for attribute filtering

### DIFF
--- a/src/lib/redshift-pg.js
+++ b/src/lib/redshift-pg.js
@@ -44,14 +44,14 @@ async function getAggregatedUsersBy(timeUnit, aggregationType, data) {
     dateRangeStart = ADJUST_DATE[timeUnit](previous, new Date());
   }
 
-  const { event_name, filterAttribute, filterAttributeValue } = data;
+  const { eventName, filters } = data;
 
   const result = await dbQuery(
     AGGREGATE_USERS[aggregationType](timeUnit),
     dateRangeStart,
-    event_name,
-    filterAttribute,
-    filterAttributeValue,
+    eventName,
+    filters ? filters.events : {},
+    filters ? filters.users : {},
   );
 
   return formatDataBy(timeUnit, result.rows, previous);
@@ -68,14 +68,14 @@ async function getAggregatedEventsBy(timeUnit, aggregationType, data) {
     dateRangeStart = ADJUST_DATE[timeUnit](previous, new Date());
   }
 
-  const { event_name, filterAttribute, filterAttributeValue } = data;
+  const { eventName, filters } = data;
 
   const result = await dbQuery(
     AGGREGATE_EVENTS[aggregationType](timeUnit),
     dateRangeStart,
-    event_name,
-    filterAttribute,
-    filterAttributeValue,
+    eventName,
+    filters ? filters.events : {},
+    filters ? filters.users : {},
   );
 
   return formatDataBy(timeUnit, result.rows, previous);

--- a/src/sql/redshift-tables.sql
+++ b/src/sql/redshift-tables.sql
@@ -7,7 +7,6 @@ CREATE TABLE public.users (
 
 CREATE TABLE public.events (   
     id                INTEGER IDENTITY(1,1) PRIMARY KEY,
-    event_id          VARCHAR(50) NOT NULL,
     event_name        VARCHAR(255),
     user_id           VARCHAR(50) REFERENCES Users(id),
     event_attributes  SUPER, -- Use SUPER data type for JSON

--- a/src/sql/redshift-tables.sql
+++ b/src/sql/redshift-tables.sql
@@ -13,3 +13,21 @@ CREATE TABLE public.events (
     event_attributes  SUPER, -- Use SUPER data type for JSON
     event_created     TIMESTAMP DEFAULT SYSDATE
 );
+
+CREATE FUNCTION attr_validate (filter_obj VARCHAR(max), attributes VARCHAR(max))
+  returns bool
+stable
+as $$
+    import json
+    parsed_filter_obj = json.loads(filter_obj)
+    parsed_attributes = json.loads(attributes)
+
+    for attribute in parsed_filter_obj:
+        if (
+            attribute not in parsed_attributes
+            or parsed_attributes[attribute] not in parsed_filter_obj[attribute]
+        ):
+            return False
+
+    return True
+$$ language plpythonu;

--- a/src/sql/users.js
+++ b/src/sql/users.js
@@ -6,13 +6,15 @@ function getTotalUsersBy(timeUnit) {
   return `
     SELECT
       DATE_TRUNC('${VALID_TIME_UNIT[timeUnit]}', CAST(event_created AS TIMESTAMPTZ)) AS ${timeUnit},
-      COUNT(DISTINCT user_id) AS calculated_value
+      COUNT(DISTINCT events.user_id) AS calculated_value
     FROM
-      events
+      events e
+    JOIN users u ON e.user_id = u.user_id
     WHERE
       (CAST($1 AS TIMESTAMP) IS NULL OR event_created BETWEEN $1 AND SYSDATE)
       AND (CAST($2 AS VARCHAR) IS NULL OR event_name = $2)
-      AND (CAST($3 AS VARCHAR) IS NULL OR JSON_EXTRACT_PATH_TEXT(JSON_SERIALIZE(event_attributes), $3) = $4)
+      AND (CAST($3 AS VARCHAR) IS NULL OR attr_validate($3, JSON_SERIALIZE(e.event_attributes)))
+      AND (CAST($4 AS VARCHAR) IS NULL OR attr_validate($4, JSON_SERIALIZE(u.user_attributes)))
     GROUP BY
       ${timeUnit}
   `;


### PR DESCRIPTION
I implemented a Redshift UDF (user defined function) named `attr_validate` to allow for more complex comparisons between filter values and attributes. 

NOTE about testing: 
For any devs testing with a Redshift cluster, **you must re-provision** via terraform to gain access to this function, or directly add it from the AWS Redshift Query editor in the console.

The function allows for multiple filtered attribute values from the frontend to be validated against an event. An event is valid only if it has an attribute that matches any of the valid filter values for the specified attribute. If an attribute is excluded, then it is not included in filtering. It can be used by passing a `filters` object in the format of:

```javascript
{
  events: { device: ["desktop", "tablet"], location: ["Boston"] },
  users: { paidMember: [true] }
}
```

followed by a stringified version of an attribute field e.g. JSON_SERIALIZE(event_attirubtes)

The new way to invocate our aggregation functions looks like:

```javascript
getAggregatedEventsBy("month", "total", {
  previous: 3,
  filters: {
    events: { device: ["desktop", "tablet"] },
    users: { paidMember: [true] },
  },
})
```

There is an edge case that may arise where something like:

```
{
  events: { device: [], location: ["Boston"] },
  users: { paidMember: [true] }
}
```

where now all events with a `device` attribute do not match, as there are no valid values in the device array

I feel that this is more appropriately handled on the frontend, as technically the logic here still makes sense, and an empty array should probably not be sent, but I am open to addressing this as well