### PR TITLE
Bug fixes for improper alias use in queries

### DIFF
--- a/src/lib/redshift-pg.js
+++ b/src/lib/redshift-pg.js
@@ -5,7 +5,7 @@ const events = require("../sql/events");
 const users = require("../sql/users");
 const { VALID_TIME_UNIT } = require("../lib/globals");
 const formatDataBy = require("../utils/format-records");
-const formatAttributes = require('../utils/format-attributes')
+const formatAttributes = require("../utils/format-attributes");
 
 const AGGREGATE_EVENTS = {
   total: events.getTotalEventsBy,
@@ -45,9 +45,7 @@ async function getAggregatedUsersBy(timeUnit, aggregationType, options) {
     dateRangeStart = ADJUST_DATE[timeUnit](previous, new Date());
   }
 
-
   const { eventName, filters } = options;
-
 
   const result = await dbQuery(
     AGGREGATE_USERS[aggregationType](timeUnit),
@@ -70,7 +68,6 @@ async function getAggregatedEventsBy(timeUnit, aggregationType, options) {
   if (previous) {
     dateRangeStart = ADJUST_DATE[timeUnit](previous, new Date());
   }
-
 
   const { eventName, filters } = options;
 
@@ -105,7 +102,7 @@ async function getAllAttributes() {
     let userAttributes = dbQuery(users.getAllUserAttributes());
     result = await Promise.all([eventAttributes, userAttributes]);
     let formattedResult = formatAttributes(result);
-    return formattedResult
+    return formattedResult;
   } catch (error) {
     console.error(error);
   }

--- a/src/sql/events.js
+++ b/src/sql/events.js
@@ -16,7 +16,7 @@ function getAllEventAttributes() {
       JSON_SERIALIZE(event_attributes)
     FROM
       events
-  `
+  `;
 }
 
 function getTotalEventsBy(timeUnit) {
@@ -79,7 +79,7 @@ function getMinPerUserBy(timeUnit) {
     SELECT
       DATE_TRUNC('${timeUnit}', CAST(event_created AS TIMESTAMPTZ)) AS ${timeUnit},
       COUNT(DISTINCT e.id) AS calculated_value,
-      user_id
+      e.user_id
     FROM
       events e
     LEFT JOIN
@@ -90,7 +90,7 @@ function getMinPerUserBy(timeUnit) {
       AND (CAST($3 AS VARCHAR) IS NULL OR attr_validate($3, JSON_SERIALIZE(e.event_attributes)))
       AND (CAST($4 AS VARCHAR) IS NULL OR attr_validate($4, JSON_SERIALIZE(u.user_attributes)))
     GROUP BY
-      ${timeUnit}, user_id
+      ${timeUnit}, e.user_id
   )
   SELECT
     ${timeUnit},
@@ -110,7 +110,7 @@ function getMaxPerUserBy(timeUnit) {
     SELECT
       DATE_TRUNC('${timeUnit}', CAST(event_created AS TIMESTAMPTZ)) AS ${timeUnit},
       COUNT(DISTINCT e.id) AS calculated_value,
-      user_id
+      e.user_id
     FROM
       events e
     LEFT JOIN
@@ -121,7 +121,7 @@ function getMaxPerUserBy(timeUnit) {
       AND (CAST($3 AS VARCHAR) IS NULL OR attr_validate($3, JSON_SERIALIZE(e.event_attributes)))
       AND (CAST($4 AS VARCHAR) IS NULL OR attr_validate($4, JSON_SERIALIZE(u.user_attributes)))
     GROUP BY
-      ${timeUnit}, user_id
+      ${timeUnit}, e.user_id
   )
   SELECT
     ${timeUnit},
@@ -139,7 +139,7 @@ function getMedianPerUserBy(timeUnit) {
   return `
     WITH event_counts AS (
       SELECT
-        user_id,
+        e.user_id,
         DATE_TRUNC('hour', CAST(event_created AS TIMESTAMPTZ)) AS ${timeUnit},
         COUNT(DISTINCT e.id) as num_events
       FROM events e
@@ -151,8 +151,8 @@ function getMedianPerUserBy(timeUnit) {
         AND (CAST($3 AS VARCHAR) IS NULL OR attr_validate($3, JSON_SERIALIZE(e.event_attributes)))
         AND (CAST($4 AS VARCHAR) IS NULL OR attr_validate($4, JSON_SERIALIZE(u.user_attributes)))
       GROUP BY
-        user_id,
-        DATE_TRUNC('hour', CAST(event_created AS TIMESTAMPTZ))
+        e.user_id,
+        ${timeUnit}
     ),
     user_event_counts AS (
       SELECT

--- a/src/sql/users.js
+++ b/src/sql/users.js
@@ -7,7 +7,7 @@ function getAllUserAttributes() {
       JSON_SERIALIZE(user_attributes)
     FROM
       users
-  `
+  `;
 }
 
 function getTotalUsersBy(timeUnit) {
@@ -16,7 +16,7 @@ function getTotalUsersBy(timeUnit) {
   return `
     SELECT
       DATE_TRUNC('${VALID_TIME_UNIT[timeUnit]}', CAST(event_created AS TIMESTAMPTZ)) AS ${timeUnit},
-      COUNT(DISTINCT events.user_id) AS calculated_value
+      COUNT(DISTINCT e.user_id) AS calculated_value
     FROM
       events e
     JOIN users u ON e.user_id = u.user_id


### PR DESCRIPTION
A previous PR required aliases to be used in SQL queries to make certain field name unambiguous. The aliases were not applied in all situations, causing some queries to throw errors. This fixes that issue.