### PR TITLE
Typo fix

### DIFF
--- a/src/utils/format-attributes.js
+++ b/src/utils/format-attributes.js
@@ -1,27 +1,28 @@
 function formatAttributes(result) {
   let attributeObj = {
     event: getDistinctAttributes(result[0]),
-    user: getDistinctAttributes(result[1])
-  }
+    user: getDistinctAttributes(result[1]),
+  };
 
   return attributeObj;
 }
 
 function getDistinctAttributes(attributeArr) {
-  let formattedAttributes = {};
-  attributeArr.rows.forEach(row => {
+  let formattedAtrributes = {};
+  attributeArr.rows.forEach((row) => {
     let attributes = JSON.parse(row.json_serialize);
     for (let attribute in attributes) {
       let value = attributes[attribute];
-      if (!newObj.hasOwnProperty(attribute)) {
-        newObj[attribute] = [];
+      if (!formattedAtrributes.hasOwnProperty(attribute)) {
+        formattedAtrributes[attribute] = [];
       }
-      if (!newObj[attribute].includes(value)) {
-        newObj[attribute].push(String(value))
+      if (!formattedAtrributes[attribute].includes(value)) {
+        formattedAtrributes[attribute].push(String(value));
       }
     }
-  })
-  return formattedAttributes;
+  });
+
+  return formattedAtrributes;
 }
 
-module.exports = formatAttributes
+module.exports = formatAttributes;


### PR DESCRIPTION
There was an issue in the changed function that has conflicting variable names where a single variable was meant. This threw an error when a method was called on `undefined`.